### PR TITLE
feat: restore deepin patches on mpv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /subprojects/*
 !/subprojects/packagefiles
 !/subprojects/*.wrap
+.pc/

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+mpv (0.40.0-3+deb13u1deepin1) unstable; urgency=medium
+
+  * Restore deepin-specific patches from master branch:
+    - pgv-flower-screen: Fix flower screen issue
+    - vdpau-render: Add VDPAU rendering support
+    - Fix-the-problem-of-the-full-screen-crash: Fix full screen crash in vaapi
+    - fix-mpv: Fix OpenGL rendering issues
+
+ -- lichenggang <lichenggang@uniontech.com>  Fri, 17 Jul 2026 23:30:00 +0800
+
 mpv (0.40.0-3+deb13u1) trixie; urgency=medium
 
   * debian/gbp.conf: Work on debian/trixie branch

--- a/debian/patches/Fix-the-problem-of-the-full-screen-crash.patch
+++ b/debian/patches/Fix-the-problem-of-the-full-screen-crash.patch
@@ -1,0 +1,293 @@
+Index: mpv-master/video/out/vo_vaapi.c
+===================================================================
+--- mpv-master.orig/video/out/vo_vaapi.c
++++ mpv-master/video/out/vo_vaapi.c
+@@ -32,7 +32,6 @@
+ #include "video/out/vo.h"
+ #include "video/mp_image_pool.h"
+ #include "video/sws_utils.h"
+-#include "sub/draw_bmp.h"
+ #include "sub/img_convert.h"
+ #include "sub/osd.h"
+ #include "present_sync.h"
+@@ -84,9 +83,8 @@ struct priv {
+     bool                     force_scaled_osd;
+ 
+     VAImageFormat            osd_format; // corresponds to OSD_VA_FORMAT
+-    struct vaapi_osd_part    osd_part;
++    struct vaapi_osd_part    osd_parts[MAX_OSD_PARTS];
+     bool                     osd_screen;
+-    struct mp_draw_sub_cache *osd_cache;
+ 
+     struct mp_image_pool    *pool;
+ 
+@@ -104,6 +102,12 @@ struct priv {
+ 
+ #define OSD_VA_FORMAT VA_FOURCC_BGRA
+ 
++static const bool osd_formats[SUBBITMAP_COUNT] = {
++    // Actually BGRA, but only on little endian.
++    // This will break on big endian, I think.
++    [SUBBITMAP_BGRA] = true,
++};
++
+ static void draw_osd(struct vo *vo);
+ 
+ 
+@@ -503,20 +507,22 @@ static bool render_to_screen(struct priv
+     if (surface == VA_INVALID_ID)
+         return false;
+ 
+-    struct vaapi_osd_part *part = &p->osd_part;
+-    if (part->active) {
+-        struct vaapi_subpic *sp = &part->subpic;
+-        int flags = 0;
+-        if (p->osd_screen)
+-            flags |= VA_SUBPICTURE_DESTINATION_IS_SCREEN_COORD;
+-        status = vaAssociateSubpicture(p->display,
+-                                       sp->id, &surface, 1,
+-                                       sp->src_x, sp->src_y,
+-                                       sp->src_w, sp->src_h,
+-                                       sp->dst_x, sp->dst_y,
+-                                       sp->dst_w, sp->dst_h,
+-                                       flags);
+-        CHECK_VA_STATUS(p, "vaAssociateSubpicture()");
++    for (int n = 0; n < MAX_OSD_PARTS; n++) {
++        struct vaapi_osd_part *part = &p->osd_parts[n];
++        if (part->active) {
++            struct vaapi_subpic *sp = &part->subpic;
++            int flags = 0;
++            if (p->osd_screen)
++                flags |= VA_SUBPICTURE_DESTINATION_IS_SCREEN_COORD;
++            status = vaAssociateSubpicture(p->display,
++                                           sp->id, &surface, 1,
++                                           sp->src_x, sp->src_y,
++                                           sp->src_w, sp->src_h,
++                                           sp->dst_x, sp->dst_y,
++                                           sp->dst_w, sp->dst_h,
++                                           flags);
++            CHECK_VA_STATUS(p, "vaAssociateSubpicture()");
++        }
+     }
+ 
+     int flags = va_get_colorspace_flag(p->image_params.repr.sys) |
+@@ -536,11 +542,14 @@ static bool render_to_screen(struct priv
+                           flags);
+     CHECK_VA_STATUS(p, "vaPutSurface()");
+ 
+-    if (part->active) {
+-        struct vaapi_subpic *sp = &part->subpic;
+-        status = vaDeassociateSubpicture(p->display, sp->id,
+-                                         &surface, 1);
+-        CHECK_VA_STATUS(p, "vaDeassociateSubpicture()");
++    for (int n = 0; n < MAX_OSD_PARTS; n++) {
++        struct vaapi_osd_part *part = &p->osd_parts[n];
++        if (part->active) {
++            struct vaapi_subpic *sp = &part->subpic;
++            status = vaDeassociateSubpicture(p->display, sp->id,
++                                             &surface, 1);
++            CHECK_VA_STATUS(p, "vaDeassociateSubpicture()");
++        }
+     }
+ 
+     return true;
+@@ -625,89 +634,108 @@ error:
+     return -1;
+ }
+ 
+-static void draw_osd(struct vo *vo)
++static void draw_osd_cb(void *pctx, struct sub_bitmaps *imgs)
+ {
+-    struct priv *p = vo->priv;
+-
+-    struct mp_image *cur = p->output_surfaces[p->output_surface];
+-    double pts = cur ? cur->pts : 0;
+-
+-    if (!p->osd_format.fourcc)
+-        return;
+-
+-    struct mp_osd_res vid_res = osd_res_from_image_params(vo->params);
++    struct priv *p = pctx;
+ 
+-    struct mp_osd_res *res;
+-    if (p->osd_screen) {
+-        res = &p->screen_osd_res;
+-    } else {
+-        res = &vid_res;
+-    }
++    struct vaapi_osd_part *part = &p->osd_parts[imgs->render_index];
++    if (imgs->change_id != part->change_id) {
++        part->change_id = imgs->change_id;
+ 
+-    p->osd_part.active = false;
++        struct mp_rect bb;
++        if (!mp_sub_bitmaps_bb(imgs, &bb))
++            goto error;
+ 
+-    if (!p->osd_cache)
+-        p->osd_cache = mp_draw_sub_alloc(p, vo->global);
++        // Prevent filtering artifacts on borders
++        int pad = 2;
+ 
+-    struct sub_bitmap_list *sbs = osd_render(vo->osd, *res, pts, 0,
+-                                             mp_draw_sub_formats);
++        int w = bb.x1 - bb.x0;
++        int h = bb.y1 - bb.y0;
++        if (part->image.w < w + pad || part->image.h < h + pad) {
++            int sw = MP_ALIGN_UP(w + pad, 64);
++            int sh = MP_ALIGN_UP(h + pad, 64);
++            if (new_subpicture(p, sw, sh, &part->image) < 0)
++                goto error;
++        }
+ 
+-    struct mp_rect act_rc[1], mod_rc[64];
+-    int num_act_rc = 0, num_mod_rc = 0;
++        struct vaapi_osd_image *img = &part->image;
++        struct mp_image vaimg;
++        if (!va_image_map(p->mpvaapi, &img->image, &vaimg))
++            goto error;
+ 
+-    struct mp_image *osd = mp_draw_sub_overlay(p->osd_cache, sbs,
+-                    act_rc, MP_ARRAY_SIZE(act_rc), &num_act_rc,
+-                    mod_rc, MP_ARRAY_SIZE(mod_rc), &num_mod_rc);
++        // Clear borders and regions uncovered by sub-bitmaps
++        mp_image_clear(&vaimg, 0, 0, w + pad, h + pad);
+ 
+-    if (!osd)
+-        goto error;
++        for (int n = 0; n < imgs->num_parts; n++) {
++            struct sub_bitmap *sub = &imgs->parts[n];
++            struct mp_image src = {0};
++            mp_image_setfmt(&src, IMGFMT_BGRA);
++            mp_image_set_size(&src, sub->w, sub->h);
++            src.planes[0] = sub->bitmap;
++            src.stride[0] = sub->stride;
++
++            struct mp_image *bmp = &src;
++            struct mp_image *tmp = NULL;
++            if (sub->dw != sub->w || sub->dh != sub->h) {
++                tmp = mp_image_alloc(IMGFMT_BGRA, sub->dw, sub->dh);
++                if (!tmp)
++                    goto error;
+ 
+-    struct vaapi_osd_part *part = &p->osd_part;
++                mp_image_swscale(tmp, &src, mp_sws_fast_flags);
++                bmp = tmp;
++            }
+ 
+-    part->active = false;
++            // Note: nothing guarantees that the sub-bitmaps don't overlap.
++            //       But in all currently existing cases, they don't.
++            //       We simply hope that this won't change, and nobody will
++            //       ever notice our little shortcut here.
++
++            size_t dst = (sub->y - bb.y0) * vaimg.stride[0] +
++                         (sub->x - bb.x0) * 4;
++
++            memcpy_pic(vaimg.planes[0] + dst, bmp->planes[0], sub->dw * 4,
++                       sub->dh, vaimg.stride[0], bmp->stride[0]);
++            talloc_free(tmp);
++        }
+ 
+-    int w = res->w;
+-    int h = res->h;
+-    if (part->image.w != w || part->image.h != h) {
+-        if (new_subpicture(p, w, h, &part->image) < 0)
++        if (!va_image_unmap(p->mpvaapi, &img->image))
+             goto error;
+-    }
+-
+-    struct vaapi_osd_image *img = &part->image;
+-    struct mp_image vaimg;
+-    if (!va_image_map(p->mpvaapi, &img->image, &vaimg))
+-        goto error;
+ 
+-    for (int n = 0; n < num_mod_rc; n++) {
+-        struct mp_rect *rc = &mod_rc[n];
++        part->subpic = (struct vaapi_subpic) {
++            .id = img->subpic_id,
++            .src_x = 0,     .src_y = 0,
++            .src_w = w,     .src_h = h,
++            .dst_x = bb.x0, .dst_y = bb.y0,
++            .dst_w = w,     .dst_h = h,
++        };
++    }
+ 
+-        int rw = mp_rect_w(*rc);
+-        int rh = mp_rect_h(*rc);
++    part->active = true;
+ 
+-        void *src = mp_image_pixel_ptr(osd, 0, rc->x0, rc->y0);
+-        void *dst = vaimg.planes[0] + rc->y0 * vaimg.stride[0] + rc->x0 * 4;
++error:
++    ;
++}
+ 
+-        memcpy_pic(dst, src, rw * 4, rh, vaimg.stride[0], osd->stride[0]);
+-    }
++static void draw_osd(struct vo *vo)
++{
++    struct priv *p = vo->priv;
++    struct mp_image *cur = p->output_surfaces[p->output_surface];
++    double pts = cur ? cur->pts : 0;
+ 
+-    if (!va_image_unmap(p->mpvaapi, &img->image))
+-        goto error;
++    if (!p->osd_format.fourcc)
++        return;
+ 
+-    if (num_act_rc) {
+-        struct mp_rect rc = act_rc[0];
+-        rc.x0 = rc.y0 = 0; // must be a Mesa bug
+-        part->subpic = (struct vaapi_subpic) {
+-            .id = img->subpic_id,
+-            .src_x = rc.x0,         .src_y = rc.y0,
+-            .src_w = mp_rect_w(rc), .src_h = mp_rect_h(rc),
+-            .dst_x = rc.x0,         .dst_y = rc.y0,
+-            .dst_w = mp_rect_w(rc), .dst_h = mp_rect_h(rc),
+-        };
+-        part->active = true;
++    struct mp_osd_res vid_res = osd_res_from_image_params(vo->params);
++    struct mp_osd_res *res;
++    if (p->osd_screen) {
++        res = &p->screen_osd_res;
++    } else {
++        res = &vid_res;
+     }
+ 
+-error:
+-    talloc_free(sbs);
++    for (int n = 0; n < MAX_OSD_PARTS; n++)
++        p->osd_parts[n].active = false;
++    osd_draw(vo->osd, *res, pts, 0, osd_formats, draw_osd_cb, p);
+ }
+ 
+ static int control(struct vo *vo, uint32_t request, void *data)
+@@ -737,8 +765,10 @@ static void uninit(struct vo *vo)
+     free_video_specific(p);
+     talloc_free(p->pool);
+ 
+-    struct vaapi_osd_part *part = &p->osd_part;
+-    free_subpicture(p, &part->image);
++    for (int n = 0; n < MAX_OSD_PARTS; n++) {
++        struct vaapi_osd_part *part = &p->osd_parts[n];
++        free_subpicture(p, &part->image);
++    }
+ 
+     if (vo->hwdec_devs) {
+         hwdec_devices_remove(vo->hwdec_devs, &p->mpvaapi->hwctx);
+@@ -816,9 +846,11 @@ static int preinit(struct vo *vo)
+     if (!p->osd_format.fourcc)
+         MP_ERR(vo, "OSD format not supported. Disabling OSD.\n");
+ 
+-    struct vaapi_osd_part *part = &p->osd_part;
+-    part->image.image.image_id = VA_INVALID_ID;
+-    part->image.subpic_id = VA_INVALID_ID;
++    for (int n = 0; n < MAX_OSD_PARTS; n++) {
++        struct vaapi_osd_part *part = &p->osd_parts[n];
++        part->image.image.image_id = VA_INVALID_ID;
++        part->image.subpic_id = VA_INVALID_ID;
++    }
+ 
+     int max_display_attrs = vaMaxNumDisplayAttributes(p->display);
+     p->va_display_attrs = talloc_array(vo, VADisplayAttribute, max_display_attrs);

--- a/debian/patches/fix-mpv.patch
+++ b/debian/patches/fix-mpv.patch
@@ -1,0 +1,25 @@
+Index: mpv-master/video/out/opengl/libmpv_gl.c
+===================================================================
+--- mpv-master.orig/video/out/opengl/libmpv_gl.c
++++ mpv-master/video/out/opengl/libmpv_gl.c
+@@ -70,6 +70,7 @@ static int wrap_fbo(struct libmpv_gpu_co
+ {
+     struct priv *p = ctx->priv;
+ 
++    p->gl->Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+     mpv_opengl_fbo *fbo =
+         get_mpv_render_param(params, MPV_RENDER_PARAM_OPENGL_FBO, NULL);
+     if (!fbo)
+Index: mpv-master/video/out/opengl/ra_gl.c
+===================================================================
+--- mpv-master.orig/video/out/opengl/ra_gl.c
++++ mpv-master/video/out/opengl/ra_gl.c
+@@ -691,7 +691,7 @@ static void gl_clear(struct ra *ra, stru
+ 
+     gl->Enable(GL_SCISSOR_TEST);
+     gl->ClearColor(color[0], color[1], color[2], color[3]);
+-    gl->Clear(GL_COLOR_BUFFER_BIT);
++    gl->Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+     gl->Disable(GL_SCISSOR_TEST);
+ 
+     gl->BindFramebuffer(GL_FRAMEBUFFER, 0);

--- a/debian/patches/pgv-flower-screen.patch
+++ b/debian/patches/pgv-flower-screen.patch
@@ -1,0 +1,109 @@
+Index: mpv-master/filters/f_decoder_wrapper.c
+===================================================================
+--- mpv-master.orig/filters/f_decoder_wrapper.c
++++ mpv-master/filters/f_decoder_wrapper.c
+@@ -344,6 +344,7 @@ int mp_decoder_wrapper_control(struct mp
+                                enum dec_ctrl cmd, void *arg)
+ {
+     struct priv *p = d->f->priv;
++    p->decf->filename = d->filename;
+     int res = CONTROL_UNKNOWN;
+     if (cmd == VDCTRL_GET_HWDEC) {
+         mp_mutex_lock(&p->cache_lock);
+Index: mpv-master/filters/f_decoder_wrapper.h
+===================================================================
+--- mpv-master.orig/filters/f_decoder_wrapper.h
++++ mpv-master/filters/f_decoder_wrapper.h
+@@ -35,6 +35,8 @@ struct mp_decoder_wrapper {
+ 
+     // Can be set by user.
+     struct mp_recorder_sink *recorder_sink;
++
++    char *filename;
+ };
+ 
+ // Create the decoder wrapper for the given stream, plus underlying decoder.
+Index: mpv-master/filters/filter.h
+===================================================================
+--- mpv-master.orig/filters/filter.h
++++ mpv-master/filters/filter.h
+@@ -337,6 +337,8 @@ struct mp_filter {
+ 
+     // Private state for the generic filter code.
+     struct mp_filter_internal *in;
++
++    char *filename;
+ };
+ 
+ // Return a symbolic name, which is set at init time. NULL if no name.
+Index: mpv-master/player/video.c
+===================================================================
+--- mpv-master.orig/player/video.c
++++ mpv-master/player/video.c
+@@ -188,6 +188,7 @@ int init_video_decoder(struct MPContext
+     if (!track->dec)
+         goto err_out;
+ 
++    track->dec->filename = mpctx->filename;
+     if (!mp_decoder_wrapper_reinit(track->dec))
+         goto err_out;
+ 
+Index: mpv-master/video/decode/vd_lavc.c
+===================================================================
+--- mpv-master.orig/video/decode/vd_lavc.c
++++ mpv-master/video/decode/vd_lavc.c
+@@ -28,6 +28,8 @@
+ #include <libavutil/opt.h>
+ #include <libavutil/intreadwrite.h>
+ #include <libavutil/pixdesc.h>
++#include <libavutil/parseutils.h>
++#include <libavformat/avformat.h>
+ 
+ #include "mpv_talloc.h"
+ #include "common/global.h"
+@@ -708,6 +710,13 @@ static void init_avctx(struct mp_filter
+     avctx->codec_id = lavc_codec->id;
+     avctx->pkt_timebase = ctx->codec_timebase;
+ 
++    AVRational *timebase = &avctx->framerate;
++    char fps[50];
++    if (NULL != ctx->codec) {
++        sprintf(fps, "%.5f",ctx->codec->fps);
++        int er = av_parse_video_rate(timebase, &fps);
++    }
++
+     ctx->pic = av_frame_alloc();
+     if (!ctx->pic)
+         goto error;
+@@ -820,6 +829,23 @@ static void init_avctx(struct mp_filter
+         goto error;
+     }
+ 
++    if (vd->filename) {
++        AVFormatContext *avfctx = NULL;
++        avfctx = avformat_alloc_context();
++        if (avformat_open_input(&avfctx, vd->filename, NULL, NULL) == 0) {
++            if (avformat_find_stream_info(avfctx, NULL) >= 0) {
++                AVCodecParameters *codec_par = avfctx->streams[0]->codecpar;
++                const AVCodec *codec = avcodec_find_decoder(codec_par->codec_id);
++                if (codec && codec->type == AVMEDIA_TYPE_VIDEO) {
++                    avctx->profile = codec->profiles;
++                    avctx->level = codec_par->level;
++                }
++            }
++        }
++
++        avformat_close_input(&avfctx);
++    }
++
+     /* open it */
+     if (avcodec_open2(avctx, lavc_codec, NULL) < 0)
+         goto error;
+@@ -1410,6 +1436,7 @@ static struct mp_decoder *create(struct
+                                  const char *decoder)
+ {
+     struct mp_filter *vd = mp_filter_create(parent, &vd_lavc_filter);
++    vd->filename = parent->filename;
+     if (!vd)
+         return NULL;
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,5 @@
 0001-player-create-missing-folders-for-watch-history-path.patch
+pgv-flower-screen.patch
+vdpau-render.patch
+Fix-the-problem-of-the-full-screen-crash.patch
+fix-mpv.patch

--- a/debian/patches/vdpau-render.patch
+++ b/debian/patches/vdpau-render.patch
@@ -1,0 +1,385 @@
+Index: mpv-master/video/out/gpu/context.c
+===================================================================
+--- mpv-master.orig/video/out/gpu/context.c
++++ mpv-master/video/out/gpu/context.c
+@@ -35,6 +35,7 @@
+ 
+ /* OpenGL */
+ extern const struct ra_ctx_fns ra_ctx_glx;
++extern const struct ra_ctx_fns ra_ctx_glx_probe;
+ extern const struct ra_ctx_fns ra_ctx_x11_egl;
+ extern const struct ra_ctx_fns ra_ctx_drm_egl;
+ extern const struct ra_ctx_fns ra_ctx_wayland_egl;
+@@ -78,6 +79,9 @@ static const struct ra_ctx_fns *contexts
+ #if HAVE_EGL_WAYLAND
+     &ra_ctx_wayland_egl,
+ #endif
++#if HAVE_GL_X11
++    &ra_ctx_glx_probe,
++#endif
+ #if HAVE_EGL_X11
+     &ra_ctx_x11_egl,
+ #endif
+Index: mpv-master/video/out/gpu/hwdec.h
+===================================================================
+--- mpv-master.orig/video/out/gpu/hwdec.h
++++ mpv-master/video/out/gpu/hwdec.h
+@@ -69,6 +69,7 @@ struct ra_hwdec_mapper {
+     // The common code won't mess with these, so you can e.g. set them in the
+     // .init() callback.
+     struct ra_tex *tex[4];
++    bool vdpau_fields;
+ };
+ 
+ // This can be used to map frames of a specific hw format as GL textures.
+Index: mpv-master/video/out/gpu/video.c
+===================================================================
+--- mpv-master.orig/video/out/gpu/video.c
++++ mpv-master/video/out/gpu/video.c
+@@ -219,6 +219,7 @@ struct gl_video {
+     struct ra_tex *error_diffusion_tex[2];
+     struct ra_tex *screen_tex;
+     struct ra_tex *output_tex;
++    struct ra_tex *vdpau_deinterleave_tex[2];
+     struct ra_tex **hook_textures;
+     int num_hook_textures;
+     int idx_hook_textures;
+@@ -1052,6 +1053,8 @@ static void uninit_video(struct gl_video
+     p->hwdec_active = false;
+     p->hwdec_overlay = NULL;
+     ra_hwdec_mapper_free(&p->hwdec_mapper);
++    for (int n = 0; n < 2; n++)
++        ra_tex_free(p->ra, &p->vdpau_deinterleave_tex[n]);
+ }
+ 
+ static void pass_record(struct gl_video *p, const struct mp_pass_perf *perf)
+@@ -3635,6 +3638,42 @@ void gl_video_perfdata(struct gl_video *
+     frame_perf_data(p->pass_redraw, &out->redraw);
+ }
+ 
++// This assumes nv12, with textures set to GL_NEAREST filtering.
++static void reinterleave_vdpau(struct gl_video *p,
++                               struct ra_tex *input[4], struct ra_tex *output[2])
++{
++    for (int n = 0; n < 2; n++) {
++        struct ra_tex **tex = &p->vdpau_deinterleave_tex[n];
++        // This is an array of the 2 to-merge planes.
++        struct ra_tex **src = &input[n * 2];
++        int w = src[0]->params.w;
++        int h = src[0]->params.h;
++        int ids[2];
++        for (int t = 0; t < 2; t++) {
++            ids[t] = pass_bind(p, (struct image){
++                .tex = src[t],
++                .multiplier = 1.0,
++                .transform = identity_trans,
++                .w = w,
++                .h = h,
++            });
++        }
++
++        pass_describe(p, "vdpau reinterleaving");
++        GLSLF("color = fract(gl_FragCoord.y * 0.5) < 0.5\n");
++        GLSLF("      ? texture(texture%d, texcoord%d)\n", ids[0], ids[0]);
++        GLSLF("      : texture(texture%d, texcoord%d);", ids[1], ids[1]);
++
++        int comps = n == 0 ? 1 : 2;
++        const struct ra_format *fmt = ra_find_unorm_format(p->ra, 1, comps);
++        ra_tex_resize(p->ra, p->log, tex, w, h * 2, fmt);
++        const struct ra_fbo fbo = { *tex };
++        finish_pass_fbo(p, &fbo, true, &(struct mp_rect){0, 0, w, h * 2});
++
++        output[n] = *tex;
++    }
++}
++
+ // Returns false on failure.
+ static bool pass_upload_image(struct gl_video *p, struct mp_image *mpi, uint64_t id)
+ {
+@@ -3672,6 +3711,11 @@ static bool pass_upload_image(struct gl_
+             struct mp_image layout = {0};
+             mp_image_set_params(&layout, &p->image_params);
+             struct ra_tex **tex = p->hwdec_mapper->tex;
++            struct ra_tex *tmp[4] = {0};
++            if (p->hwdec_mapper->vdpau_fields) {
++                reinterleave_vdpau(p, tex, tmp);
++                tex = tmp;
++            }
+             for (int n = 0; n < p->plane_count; n++) {
+                 vimg->planes[n] = (struct texplane){
+                     .w = mp_image_plane_w(&layout, n),
+Index: mpv-master/video/out/opengl/context_glx.c
+===================================================================
+--- mpv-master.orig/video/out/opengl/context_glx.c
++++ mpv-master/video/out/opengl/context_glx.c
+@@ -308,6 +308,20 @@ uninit:
+     return false;
+ }
+ 
++static bool glx_init_probe(struct ra_ctx *ctx)
++{
++    if (!glx_init(ctx))
++        return false;
++
++    struct priv *p = ctx->priv;
++    if (!(p->gl.mpgl_caps & MPGL_CAP_VDPAU)) {
++        MP_VERBOSE(ctx, "No vdpau support found - probing more things.\n");
++        glx_uninit(ctx);
++        return false;
++    }
++
++    return true;
++}
+ 
+ static void resize(struct ra_ctx *ctx)
+ {
+@@ -349,3 +363,14 @@ const struct ra_ctx_fns ra_ctx_glx = {
+     .init           = glx_init,
+     .uninit         = glx_uninit,
+ };
++
++const struct ra_ctx_fns ra_ctx_glx_probe = {
++    .type           = "opengl",
++    .name           = "x11probe",
++    .reconfig       = glx_reconfig,
++    .control        = glx_control,
++    .wakeup         = glx_wakeup,
++    .wait_events    = glx_wait_events,
++    .init           = glx_init_probe,
++    .uninit         = glx_uninit,
++};
+Index: mpv-master/video/out/opengl/hwdec_vdpau.c
+===================================================================
+--- mpv-master.orig/video/out/opengl/hwdec_vdpau.c
++++ mpv-master/video/out/opengl/hwdec_vdpau.c
+@@ -18,6 +18,8 @@
+ #include <stddef.h>
+ #include <assert.h>
+ 
++#include <GL/glx.h>
++
+ #include "video/out/gpu/hwdec.h"
+ #include "ra_gl.h"
+ #include "video/vdpau.h"
+@@ -35,19 +37,19 @@ struct priv {
+     struct mp_vdpau_ctx *ctx;
+     GL *gl;
+     uint64_t preemption_counter;
+-    GLuint gl_texture;
++    GLuint gl_textures[4];
+     bool vdpgl_initialized;
+     GLvdpauSurfaceNV vdpgl_surface;
+     VdpOutputSurface vdp_surface;
+     struct mp_vdpau_mixer *mixer;
+-    struct ra_imgfmt_desc direct_desc;
++    bool direct_mode;
+     bool mapped;
+ };
+ 
+ static int init(struct ra_hwdec *hw)
+ {
+     struct ra *ra = hw->ra_ctx->ra;
+-    Display *x11disp = ra_get_native_resource(ra, "x11");
++    Display *x11disp = glXGetCurrentDisplay();
+     if (!x11disp || !ra_is_gl(ra))
+         return -1;
+     GL *gl = ra_gl_get(ra);
+@@ -86,6 +88,10 @@ static void mapper_unmap(struct ra_hwdec
+ 
+     if (p->mapped) {
+         gl->VDPAUUnmapSurfacesNV(1, &p->vdpgl_surface);
++        if (p->direct_mode) {
++            gl->VDPAUUnregisterSurfaceNV(p->vdpgl_surface);
++            p->vdpgl_surface = 0;
++        }
+     }
+     p->mapped = false;
+ }
+@@ -111,7 +117,7 @@ static void mapper_uninit(struct ra_hwde
+         gl->VDPAUUnregisterSurfaceNV(p->vdpgl_surface);
+     p->vdpgl_surface = 0;
+ 
+-    gl->DeleteTextures(1, &p->gl_texture);
++    gl->DeleteTextures(4, p->gl_textures);
+ 
+     if (p->vdp_surface != VDP_INVALID_HANDLE) {
+         vdp_st = vdp->output_surface_destroy(p->vdp_surface);
+@@ -157,32 +163,50 @@ static int mapper_init(struct ra_hwdec_m
+ 
+     p->vdpgl_initialized = true;
+ 
+-    gl->GenTextures(1, &p->gl_texture);
+-
+-    gl->BindTexture(GL_TEXTURE_2D, p->gl_texture);
+-    gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+-    gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+-    gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+-    gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+-    gl->BindTexture(GL_TEXTURE_2D, 0);
+-
+-    vdp_st = vdp->output_surface_create(p->ctx->vdp_device,
+-                                        VDP_RGBA_FORMAT_B8G8R8A8,
+-                                        mapper->src_params.w,
+-                                        mapper->src_params.h,
+-                                        &p->vdp_surface);
+-    CHECK_VDP_ERROR(mapper, "Error when calling vdp_output_surface_create");
+-
+-    p->vdpgl_surface = gl->VDPAURegisterOutputSurfaceNV(BRAINDEATH(p->vdp_surface),
+-                                                        GL_TEXTURE_2D,
+-                                                        1, &p->gl_texture);
+-    if (!p->vdpgl_surface)
+-        return -1;
++    p->direct_mode = mapper->dst_params.hw_subfmt == IMGFMT_NV12 ||
++                     mapper->dst_params.hw_subfmt == IMGFMT_420P;
++    mapper->vdpau_fields = p->direct_mode;
++
++    gl->GenTextures(4, p->gl_textures);
++
++    if (p->direct_mode) {
++        mapper->dst_params.imgfmt = IMGFMT_NV12;
++        mapper->dst_params.hw_subfmt = 0;
++
++        for (int n = 0; n < 4; n++) {
++            gl->BindTexture(GL_TEXTURE_2D, p->gl_textures[n]);
++            gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
++            gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
++            gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
++            gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
++            gl->BindTexture(GL_TEXTURE_2D, 0);
++        }
++    } else {
++        gl->BindTexture(GL_TEXTURE_2D, p->gl_textures[0]);
++        gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
++        gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
++        gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
++        gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
++        gl->BindTexture(GL_TEXTURE_2D, 0);
++
++        vdp_st = vdp->output_surface_create(p->ctx->vdp_device,
++                                            VDP_RGBA_FORMAT_B8G8R8A8,
++                                            mapper->src_params.w,
++                                            mapper->src_params.h,
++                                            &p->vdp_surface);
++        CHECK_VDP_ERROR(mapper, "Error when calling vdp_output_surface_create");
++
++        p->vdpgl_surface = gl->VDPAURegisterOutputSurfaceNV(BRAINDEATH(p->vdp_surface),
++                                                            GL_TEXTURE_2D,
++                                                            1, p->gl_textures);
++        if (!p->vdpgl_surface)
++            return -1;
+ 
+-    gl->VDPAUSurfaceAccessNV(p->vdpgl_surface, GL_READ_ONLY);
++        gl->VDPAUSurfaceAccessNV(p->vdpgl_surface, GL_READ_ONLY);
+ 
+-    mapper->dst_params.imgfmt = IMGFMT_RGB0;
+-    mapper->dst_params.hw_subfmt = 0;
++        mapper->dst_params.imgfmt = IMGFMT_RGB0;
++        mapper->dst_params.hw_subfmt = 0;
++    }
+ 
+     gl_check_error(gl, mapper->log, "After initializing vdpau OpenGL interop");
+ 
+@@ -193,6 +217,8 @@ static int mapper_map(struct ra_hwdec_ma
+ {
+     struct priv *p = mapper->priv;
+     GL *gl = p->gl;
++    struct vdp_functions *vdp = &p->ctx->vdp;
++    VdpStatus vdp_st;
+ 
+     int pe = mp_vdpau_handle_preemption(p->ctx, &p->preemption_counter);
+     if (pe < 1) {
+@@ -204,33 +230,73 @@ static int mapper_map(struct ra_hwdec_ma
+             return -1;
+     }
+ 
+-    if (!p->vdpgl_surface)
+-        return -1;
++    if (p->direct_mode) {
++        VdpVideoSurface surface = (intptr_t)mapper->src->planes[3];
++
++        // We need the uncropped size.
++        VdpChromaType s_chroma_type;
++        uint32_t s_w, s_h;
++        vdp_st = vdp->video_surface_get_parameters(surface, &s_chroma_type, &s_w, &s_h);
++        CHECK_VDP_ERROR(mapper, "Error when calling vdp_video_surface_get_parameters");
++
++        p->vdpgl_surface = gl->VDPAURegisterVideoSurfaceNV(BRAINDEATH(surface),
++                                                           GL_TEXTURE_2D,
++                                                           4, p->gl_textures);
++        if (!p->vdpgl_surface)
++            return -1;
+ 
+-    mp_vdpau_mixer_render(p->mixer, NULL, p->vdp_surface, NULL, mapper->src,
+-                            NULL);
++        gl->VDPAUSurfaceAccessNV(p->vdpgl_surface, GL_READ_ONLY);
++        gl->VDPAUMapSurfacesNV(1, &p->vdpgl_surface);
+ 
+-    gl->VDPAUMapSurfacesNV(1, &p->vdpgl_surface);
++        p->mapped = true;
+ 
+-    p->mapped = true;
++        for (int n = 0; n < 4; n++) {
++            bool chroma = n >= 2;
++            struct ra_tex_params params = {
++                .dimensions = 2,
++                .w = s_w / (chroma ? 2 : 1),
++                .h = s_h / (chroma ? 4 : 2),
++                .d = 1,
++                .format = ra_find_unorm_format(mapper->ra, 1, chroma ? 2 : 1),
++                .render_src = true,
++            };
++
++            if (!params.format)
++                return -1;
++
++            mapper->tex[n] =
++                ra_create_wrapped_tex(mapper->ra, &params, p->gl_textures[n]);
++            if (!mapper->tex[n])
++                return -1;
++        }
++    } else {
++        if (!p->vdpgl_surface)
++            return -1;
++        mp_vdpau_mixer_render(p->mixer, NULL, p->vdp_surface, NULL, mapper->src,
++                              NULL);
+ 
+-    struct ra_tex_params params = {
+-        .dimensions = 2,
+-        .w = mapper->src_params.w,
+-        .h = mapper->src_params.h,
+-        .d = 1,
+-        .format = ra_find_unorm_format(mapper->ra, 1, 4),
+-        .render_src = true,
+-        .src_linear = true,
+-    };
++        gl->VDPAUMapSurfacesNV(1, &p->vdpgl_surface);
+ 
+-    if (!params.format)
+-        return -1;
++        p->mapped = true;
+ 
+-    mapper->tex[0] =
+-        ra_create_wrapped_tex(mapper->ra, &params, p->gl_texture);
+-    if (!mapper->tex[0])
+-        return -1;
++        struct ra_tex_params params = {
++            .dimensions = 2,
++            .w = mapper->src_params.w,
++            .h = mapper->src_params.h,
++            .d = 1,
++            .format = ra_find_unorm_format(mapper->ra, 1, 4),
++            .render_src = true,
++            .src_linear = true,
++        };
++
++        if (!params.format)
++            return -1;
++
++        mapper->tex[0] =
++            ra_create_wrapped_tex(mapper->ra, &params, p->gl_textures[0]);
++        if (!mapper->tex[0])
++            return -1;
++    }
+ 
+     return 0;
+ }


### PR DESCRIPTION
Restore deepin-specific patches from master branch:
- pgv-flower-screen: Fix flower screen issue during video playback
- vdpau-render: Add VDPAU rendering support
- Fix-the-problem-of-the-full-screen-crash: Fix full screen crash in vaapi
- fix-mpv: Fix OpenGL rendering issues (GL_DEPTH_BUFFER)

Note: fix-vaapi-nullpter-crush patch was skipped because the same fixes are already present in upstream 0.40.0.

Related: automated backport of deepin patches.